### PR TITLE
✨ feat: Add GitHub stars fetching to ProjectCard component

### DIFF
--- a/.vitepress/theme/components/ProjectCard.vue
+++ b/.vitepress/theme/components/ProjectCard.vue
@@ -1,12 +1,27 @@
 <script setup lang="ts">
 import { type Project } from "../../types/project";
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vitepress";
+import { getGitHubStars } from "../utils/github";
 
 const router = useRouter();
 const props = defineProps<{
   project: Project;
 }>();
+
+// 获取 GitHub stars
+const stars = ref<number | null>(props.project.stars || null);
+
+onMounted(async () => {
+  if (props.project.github && !stars.value) {
+    const count = await getGitHubStars(props.project.github);
+    if (count !== null) {
+      stars.value = count;
+    } else {
+      stars.value = 0;
+    }
+  }
+});
 
 const navigateToDoc = () => {
   router.go(props.project.docPath);
@@ -114,16 +129,19 @@ const defaultLogoText = computed(() => {
           class="action-button github"
           title="View on GitHub"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
-            />
-          </svg>
+          <div class="github-info">
+            <span v-if="stars" class="stars"> {{ stars }}</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+              />
+            </svg>
+          </div>
         </a>
         <a
           v-if="project.website"
@@ -425,5 +443,20 @@ const defaultLogoText = computed(() => {
 
 .action-button:hover svg {
   transform: scale(1.1);
+}
+
+.github-info {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.stars {
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+
+.dark .stars {
+  color: var(--vp-c-text-1);
 }
 </style>

--- a/.vitepress/theme/utils/github.ts
+++ b/.vitepress/theme/utils/github.ts
@@ -1,0 +1,41 @@
+/**
+ * 从 GitHub URL 中提取仓库信息
+ * @param url GitHub 仓库 URL
+ * @returns owner 和 repo
+ */
+function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
+  try {
+    const urlObj = new URL(url);
+    if (urlObj.hostname !== 'github.com') return null;
+    
+    const [, owner, repo] = urlObj.pathname.split('/');
+    if (!owner || !repo) return null;
+    
+    return { owner, repo };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 获取 GitHub 仓库的 stars 数量
+ * @param url GitHub 仓库 URL
+ * @returns stars 数量
+ */
+export async function getGitHubStars(url: string): Promise<number | null> {
+  const repoInfo = parseGitHubUrl(url);
+  if (!repoInfo) return null;
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repoInfo.owner}/${repoInfo.repo}`
+    );
+    
+    if (!response.ok) return null;
+    
+    const data = await response.json();
+    return data.stargazers_count;
+  } catch {
+    return null;
+  }
+} 

--- a/.vitepress/types/project.ts
+++ b/.vitepress/types/project.ts
@@ -5,6 +5,7 @@ export interface Project {
   website?: string;
   logo?: string;
   tags: string[];
+  stars?: number; // GitHub stars 数量
   createdAt: string; // ISO 格式的日期字符串，如：'2024-01-01'
   docPath: string; // 项目文档路径，如：'/projects/samzong-blog'
 }


### PR DESCRIPTION
feat: add GitHub stars fetching to ProjectCard component

This commit introduces functionality to fetch and display the number of GitHub stars for projects in the ProjectCard component. It enhances the user experience by providing real-time visibility into the project's popularity on GitHub. The stars are fetched from the GitHub API when the component is mounted, ensuring that users see the most current count.

Additionally, a new utility function is added to handle the GitHub URL parsing and API interaction, improving code organization and maintainability.

- Added a new utility function `getGitHubStars` to fetch stars from GitHub.
- Updated `Project` interface to include an optional `stars` property.
- Modified `ProjectCard.vue` to fetch and display stars on mount.
- Enhanced the template to show stars alongside the GitHub link.
```